### PR TITLE
support "ssh:git@~" style url

### DIFF
--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -20,6 +20,8 @@ function! s:execute_with_commit(commit, startline, endline)
     let s:repo = ''
     if s:remote =~ '^git'
         let s:repo = s:get_repo_url_from_git_protocol(s:remote)
+	elseif s:remote =~ '^ssh'
+		let s:repo = s:get_repo_url_from_ssh_protocol(s:remote)
     elseif s:remote =~ '^https'
         let s:repo = s:get_repo_url_from_https_protocol(s:remote)
     else
@@ -44,6 +46,11 @@ endfunction
 
 function! s:get_repo_url_from_git_protocol(uri)
     let s:matches = matchlist(a:uri, '^git@\(.*\):\(.*\).git')
+    return "https://" . s:matches[1] .'/' . s:matches[2]
+endfunction
+
+function! s:get_repo_url_from_ssh_protocol(uri)
+    let s:matches = matchlist(a:uri, '^ssh:\/\/git@\(.\{-\}\)\/\(.*\).git')
     return "https://" . s:matches[1] .'/' . s:matches[2]
 endfunction
 


### PR DESCRIPTION
I prefer to manage github repositories by [ghq](https://github.com/motemen/ghq).
But, it sets `remote.origin.url` as `ssh:git@~`. 
So that your plugin url parser cannot parse it and return `not match any protocol schema`


i.e.
```bash
~/gitrepos/github.com/Schumi543/vim-github-link support_ssh_style_url*
❯ git config --get remote.origin.url
ssh://git@github.com/Schumi543/vim-github-link.git
```
ref. 
https://github.com/motemen/ghq/blob/1e2298f7489c964a1a4feee881f059f3a4ecffc2/url.go#L30-L35

I enable to parse "ssh:git@~" style url.