### PR TITLE
Fix Bug #7

### DIFF
--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -43,7 +43,7 @@ function! s:execute_with_commit(commit, startline, endline)
     else
         let s:link = s:link . "#L" . a:startline . "-L". a:endline
     endif
-    let s:link = substitute(s:link, "[\n\t\s]", "", "g")
+    let s:link = substitute(s:link, "[\n\t ]", "", "g")
     let @+ = s:link
     echo 'copied ' . s:link
 endfunction


### PR DESCRIPTION
I want remote space with `\s` but neet to set ` ` directly to remove space.