### PR TITLE
Generate link to most recent commit that modified file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 vim-github-link
 ---
 
-Set link for github.com to Clipboard.
+Copy github/gitlab permalink for current line(s) to clipboard.
 
-generate url like `https://github.com/OWNER/REPO/blob/BRANCH/PATH/TO/FILE#L1-L10` and copy it to clipboard.
-there is 2 functions.
-1. generate link with current branch. like master or develop.
-2. generate link with current commit hash. url may be not found if you dont push to remote yet.
+Permalinks have the format `https://github.com/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-L10`.
+
+The plugin defines the following functions which returns different `$REF` references:
+
+- `GetCommitLink`: commit which most recently modified the current file
+- `GetCurrentBranchLink`: active branch name
+- `GetCurrentCommitLink`: most recent commit - URL will 404 if you haven't pushed it to the remote
 
 # Usage
 In normal mode
@@ -20,7 +23,7 @@ In visual mode, same command after selected.
 
 # Install
 ## dein.vim
-add below line into .vimrc 
+add below line into .vimrc
 
 ```
 call dein#add('knsh14/vim-github-link')

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 vim-github-link
 ---
 
-Copy github/gitlab permalink for current line(s) to clipboard.
+Copy github/gitlab link for current line(s) to clipboard.
 
-Permalinks have the format `https://github.com/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-L10`.
+Links have the format `https://github.com/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-L10`.
 
 The plugin defines the following functions which returns different `$REF` references:
 
-- `GetCommitLink`: commit which most recently modified the current file
+- `GetCommitLink`: commit which most recently modified the current file (permalink)
 - `GetCurrentBranchLink`: active branch name
 - `GetCurrentCommitLink`: most recent commit - URL will 404 if you haven't pushed it to the remote
 

--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -65,7 +65,6 @@ endfunction
 
 function! s:get_repo_url_from_https_protocol(uri)
     let s:matches = matchlist(a:uri, '^\(https:.*\)$')
-    echo s:matches
     return s:trim_git_suffix(s:matches[1])
 endfunction
 

--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -19,6 +19,7 @@ endfunction
 function! s:execute_with_commit(commit, startline, endline)
     let s:remote = system("git ls-remote --get-url origin")
     if s:remote !~ '.*[github|gitlab].*'
+        echoerr "Unknown remote host"
         return
     endif
 
@@ -30,7 +31,7 @@ function! s:execute_with_commit(commit, startline, endline)
     elseif s:remote =~ '^https'
         let s:repo = s:get_repo_url_from_https_protocol(s:remote)
     else
-        echoerr "not match any protocol schema"
+        echoerr "Remote doesn't match any known protocol"
         return
     endif
 

--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -1,22 +1,25 @@
-command! -range GetCurrentBranchLink <line1>,<line2>call s:get_current_branch_link()
-function! s:get_current_branch_link() range
+command! -range GetCommitLink <line1>,<line2>call s:get_commit_link("file")
+command! -range GetCurrentBranchLink <line1>,<line2>call s:get_commit_link("branch")
+command! -range GetCurrentCommitLink <line1>,<line2>call s:get_commit_link("head")
+
+function! s:get_commit_link(which_ref) range
     let s:currentdir = getcwd()
     lcd %:p:h
-    let s:branch = system("git rev-parse --abbrev-ref HEAD")
-    call s:execute_with_commit(s:branch, a:firstline, a:lastline)
+    if a:which_ref == "branch"
+      let s:ref = system("git rev-parse --abbrev-ref HEAD")
+    elseif a:which_ref == "head"
+      let s:ref = system("git rev-parse HEAD")
+    elseif a:which_ref == "file"
+      let s:ref = system("git rev-list -1 HEAD -- " . shellescape(expand('%')))
+    else
+      echoerr "Unknown ref type '" . a:which_ref . "'"
+      return
+    endif
+    call s:execute_with_ref(s:ref, a:firstline, a:lastline)
     execute 'lcd' . s:currentdir
 endfunction
 
-command! -range GetCurrentCommitLink <line1>,<line2>call s:get_current_commit_link()
-function! s:get_current_commit_link() range
-    let s:currentdir = getcwd()
-    lcd %:p:h
-    let s:commit = system("git rev-parse HEAD")
-    call s:execute_with_commit(s:commit, a:firstline, a:lastline)
-    execute 'lcd' . s:currentdir
-endfunction
-
-function! s:execute_with_commit(commit, startline, endline)
+function! s:execute_with_ref(ref, startline, endline)
     let s:remote = system("git ls-remote --get-url origin")
     if s:remote !~ '.*[github|gitlab].*'
         echoerr "Unknown remote host"
@@ -39,7 +42,7 @@ function! s:execute_with_commit(commit, startline, endline)
     let s:path_from_root = strpart(expand('%:p'), strlen(s:root))
 
     " https://github.com/OWNER/REPO/blob/BRANCH/PATH/FROM/ROOT#LN-LM
-    let s:link = s:repo . "/blob/" . a:commit . "/" . s:path_from_root
+    let s:link = s:repo . "/blob/" . a:ref . "/" . s:path_from_root
     if a:startline == a:endline
         let s:link = s:link . "#L" . a:startline
     else


### PR DESCRIPTION
This PR will generate commit links using the commit SHA that most recently modified the file, instead of simply using the most recent commit (which likely didn't touch the file in question).