### PR TITLE
Fix handling of gitlab line ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ vim-github-link
 
 Copy github/gitlab link for current line(s) to clipboard.
 
-Links have the format `https://github.com/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-L10`.
+Links have the format:
+
+- GitHub - `https://GITHUB_REMOTE_DOMAIN/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-L10`.
+- GitLab - `https://GITLAB_REMOTE_DOMAIN/OWNER/REPO/blob/$REF/PATH/TO/FILE#L1-10`.
 
 The plugin defines the following functions which returns different `$REF` references:
 

--- a/plugin/github-link.vim
+++ b/plugin/github-link.vim
@@ -46,7 +46,11 @@ function! s:execute_with_ref(ref, startline, endline)
     if a:startline == a:endline
         let s:link = s:link . "#L" . a:startline
     else
-        let s:link = s:link . "#L" . a:startline . "-L". a:endline
+        if s:remote =~ '.*github.*'
+            let s:link = s:link . "#L" . a:startline . "-L". a:endline
+        elseif s:remote =~ '.*gitlab.*'
+            let s:link = s:link . "#L" . a:startline . "-". a:endline
+        endif
     endif
     let s:link = substitute(s:link, "[\n\t ]", "", "g")
     let @+ = s:link


### PR DESCRIPTION
Gitlab line ranges have the form `#L123-456` and not `#L123-L456`